### PR TITLE
Support IndraDB 0.19.0

### DIFF
--- a/crawler.py
+++ b/crawler.py
@@ -21,7 +21,7 @@ import capnp
 import wikipedia
 import indradb
 
-PROGRESS_BAR_LENGTH = 40
+PROGRESS_BAR_LENGTH = 55
 
 # Pattern for finding internal links in wikitext
 WIKI_LINK_PATTERN = re.compile(r"\[\[([^\[\]|]+)(|[\]]+)?\]\]")
@@ -173,9 +173,10 @@ def main(archive_path):
     start_time = time.time()
     archive_size_mb = os.stat(archive_path).st_size / 1024 / 1024
 
-    with wikipedia.server():
+    with wikipedia.server(bulk_load_optimized=True):
         inserter = Inserter(wikipedia.get_client())
         streamer = ByteStreamer(archive_path)
+        print("Decompressing and indexing content...")
 
         # Now insert the articles and links iteratively
         for links_chunk in wikipedia.grouper(iterate_page_links(streamer)):
@@ -192,6 +193,8 @@ def main(archive_path):
 
         with open("data/article_names_to_ids.pickle", "wb") as f:
             inserter.dump(f)
+
+        print("Done!")
 
 if __name__ == "__main__":
     if len(sys.argv) <= 1:

--- a/explorer.py
+++ b/explorer.py
@@ -41,12 +41,12 @@ class HomeHandler(RequestHandler):
         trans.get_vertices(vertex_query)
         trans.get_edge_count(article_id, None, "outbound")
         trans.get_edges(vertex_query.outbound_edges("link", limit=1000))
-        trans.get_vertex_metadata(vertex_query.outbound_edges("link", limit=1000).inbound_vertices(), "name")
-        trans.get_vertex_metadata(vertex_query, "eigenvector-centrality")
+        trans.get_vertex_properties(vertex_query.outbound_edges("link", limit=1000).inbound_vertices(), "name")
+        trans.get_vertex_properties(vertex_query, "eigenvector-centrality")
         client = wikipedia.get_client()
         [vertex_data, edge_count, edge_data, name_data, centrality_data] = client.transaction(trans)
         inbound_edge_ids = [e.key.inbound_id for e in edge_data]
-        inbound_edge_names = {metadata.id: metadata.value for metadata in name_data}
+        inbound_edge_names = {p.id: p.value for p in name_data}
         centrality = centrality_data[0].value if len(centrality_data) > 0 else None
         
         self.render(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-indradb>=0.3.0
 tornado==4.4.2
+Cython==0.29
+indradb==0.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 tornado==4.4.2
 Cython==0.29
-indradb==0.4.0
+indradb==0.5.0

--- a/wikipedia/__init__.py
+++ b/wikipedia/__init__.py
@@ -1,3 +1,2 @@
-from .client import *
 from .proc import *
 from .util import *

--- a/wikipedia/client.py
+++ b/wikipedia/client.py
@@ -1,10 +1,7 @@
 import indradb
 
 # Location of the IndraDB server
-HOST_CONFIG = ("localhost", 8000)
-
-# How long in seconds before an IndraDB request times out
-REQUEST_TIMEOUT = 600
+HOST_CONFIG = "localhost:27615"
 
 def get_client():
-    return indradb.Client(HOST_CONFIG, request_timeout=REQUEST_TIMEOUT, scheme="http")
+    return indradb.Client(HOST_CONFIG)

--- a/wikipedia/client.py
+++ b/wikipedia/client.py
@@ -1,7 +1,0 @@
-import indradb
-
-# Location of the IndraDB server
-HOST_CONFIG = "localhost:27615"
-
-def get_client():
-    return indradb.Client(HOST_CONFIG)

--- a/wikipedia/proc.py
+++ b/wikipedia/proc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import os
 import re
 import sys
 import time
@@ -10,7 +11,7 @@ from contextlib import contextmanager
 from .client import get_client
 
 @contextmanager
-def server():
+def server(bulk_load_optimized=False):
     """
     Context manager for running the server. This starts the server up, waits
     until its responsive, then yields. When the context manager's execution is
@@ -18,7 +19,12 @@ def server():
     """
 
     # Start the process
-    server_proc = subprocess.Popen(["indradb"], stdout=sys.stdout, stderr=sys.stderr)
+    env = dict(os.environ)
+
+    if bulk_load_optimized:
+        env["ROCKSDB_BULK_LOAD_OPTIMIZED"] = "true"
+
+    server_proc = subprocess.Popen(["indradb"], stdout=sys.stdout, stderr=sys.stderr, env=env)
     
     while True:
         try:

--- a/wikipedia/proc.py
+++ b/wikipedia/proc.py
@@ -8,7 +8,9 @@ import socket
 import subprocess
 from contextlib import contextmanager
 
-from .client import get_client
+import indradb
+
+HOST_CONFIG = "localhost:27615"
 
 @contextmanager
 def server(bulk_load_optimized=False):
@@ -28,10 +30,12 @@ def server(bulk_load_optimized=False):
     
     while True:
         try:
-            client = get_client()
-            
+            client = indradb.Client(HOST_CONFIG)
+
             if client.ping().wait().ready:
                 break
+        except ConnectionRefusedError as e:
+            print(e)
         except socket.error as e:
             print(e)
 
@@ -43,7 +47,6 @@ def server(bulk_load_optimized=False):
         time.sleep(1)
 
     try:
-        yield
+        yield client
     finally:
         server_proc.terminate()
-


### PR DESCRIPTION
General updates to sync up this example to work with IndraDB 0.19.0:

* Use of capnproto-based python client
* Rename metadata to properties
* Use of bulk insert for better performance
* Removed references to centrality analysis, which there's not a good story for at the moment
* Removed outdated references

Additionally, this switches back to using shelves. This leads to better explorer startup time, at the detriment of quite a bit of extra time of the crawler (40min on my laptop.) This is better than slowing down the explorer, since the crawler is a one-time cost, but I would like to make this faster at some point.