### PR TITLE
Code cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "indradb"]
+	path = indradb
+	url = git@github.com:indradb/indradb.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -779,8 +779,6 @@ dependencies = [
 [[package]]
 name = "indradb-lib"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3e232b796b9c4791b61056d89562c6f6679ab63e664321661d4a69f40e9255e"
 dependencies = [
  "chrono",
  "failure",
@@ -794,8 +792,6 @@ dependencies = [
 [[package]]
 name = "indradb-proto"
 version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac5b20a2bed419ada9aadf66c498f560352dbd6a91df68d4abb9f932c8eca22"
 dependencies = [
  "chrono",
  "failure",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -783,7 +783,7 @@ dependencies = [
  "chrono",
  "failure",
  "lazy_static",
- "rand 0.7.3",
+ "rand 0.8.2",
  "regex",
  "serde_json",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ uuid = { version = "0.8.1", features = ["serde"] }
 blake2b_simd = "0.5.11"
 pbr = "1"
 tonic = "0.3.1"
-indradb-lib = { version = "2.0.0", path = "../indradb/lib" }
-indradb-proto = { version = "2.0.0", path = "../indradb/proto" }
+indradb-lib = { path = "indradb/lib" }
+indradb-proto = { path = "indradb/proto" }
 libc = "0.2.80"
 clap = "2"
 bzip2 = "0.4.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,8 @@ uuid = { version = "0.8.1", features = ["serde"] }
 blake2b_simd = "0.5.11"
 pbr = "1"
 tonic = "0.3.1"
-indradb-lib = { version = "2.0.0" }
-indradb-proto = { version = "2.0.0" }
+indradb-lib = { version = "2.0.0", path = "../indradb/lib" }
+indradb-proto = { version = "2.0.0", path = "../indradb/proto" }
 libc = "0.2.80"
 clap = "2"
 bzip2 = "0.4.1"

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
-.PHONY: explore
+.PHONY: explore init
+
+init:
+	git submodule update --init --recursive
+	make data/wikipedia.rdb
 
 indradb/target/release/indradb-server:
 	cd indradb/server && cargo build --release

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: explore
 
+indradb/target/release/indradb-server:
+	cd indradb/server && cargo build --release
+
 data/enwiki-latest-pages-articles.xml.bz2:
 	mkdir -p data
 	cd data && wget 'https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2'
@@ -9,12 +12,12 @@ data/archive_dump.bincode: data/enwiki-latest-pages-articles.xml.bz2
 		--archive-path data/enwiki-latest-pages-articles.xml.bz2 \
 		--dump-path data/archive_dump.bincode
 
-data/wikipedia.rdb: data/archive_dump.bincode
+data/wikipedia.rdb: data/archive_dump.bincode indradb/target/release/indradb-server
 	time cargo run --release -- index \
 		--dump-path data/archive_dump.bincode \
 		--database-path data/wikipedia.rdb
 
-explore: data/wikipedia.rdb
+explore: data/wikipedia.rdb indradb/target/release/indradb-server
 	cargo run --release -- explore --database-path data/wikipedia.rdb
 
 default: explore

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ data/enwiki-latest-pages-articles.xml.bz2:
 	cd data && wget 'https://dumps.wikimedia.org/enwiki/latest/enwiki-latest-pages-articles.xml.bz2'
 
 data/archive_dump.bincode: data/enwiki-latest-pages-articles.xml.bz2
-	cargo run --release -- parse \
+	time cargo run --release -- parse \
 		--archive-path data/enwiki-latest-pages-articles.xml.bz2 \
 		--dump-path data/archive_dump.bincode
 

--- a/README.md
+++ b/README.md
@@ -7,4 +7,4 @@ This example webapp uses [IndraDB](https://github.com/indradb/indradb) to explor
 * Make sure you have rust installed.
 * Make sure you have IndraDB installed, and that the applications are available in your `PATH`.
 * Clone the repo.
-* Run `make explore`. This will take a long time, as it'll (1) download the wikipedia dataset if you don't have it already, (2) decompress and parse the archive, and (3) index the content into IndraDB. But subsequent invocations of `make` will be snappy.
+* Run `make init explore`. This will take a long time, as it'll (1) download the wikipedia dataset if you don't have it already, (2) decompress and parse the archive, and (3) index the content into IndraDB. But subsequent invocations of `make` will be snappy.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+max_width = 120
+reorder_imports = true

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -88,7 +88,7 @@ async fn handle_article(mut client: proto::Client, tera: Tera, query: ArticleQue
     let mut trans = map_result(client.transaction().await)?;
 
     let vertices = map_result(trans.get_vertices(vertex_query.clone()).await)?;
-    if vertices.len() == 0 {
+    if vertices.is_empty() {
         return Err(warp::reject::custom(Error::ArticleNotFound { name: query.name.clone() }));
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -59,7 +59,7 @@ impl BulkInserter {
 }
 
 async fn insert_articles(client: proto::Client, article_map: &util::ArticleMap) -> Result<(), proto::ClientError> {
-    let mut progress = ProgressBar::new(article_map.uuids.len() as u64);
+    let mut progress = ProgressBar::new(article_map.article_len());
     progress.message("indexing articles: ");
 
     let mut inserter = BulkInserter::new(client);
@@ -89,7 +89,7 @@ async fn insert_articles(client: proto::Client, article_map: &util::ArticleMap) 
 }
 
 async fn insert_links(client: proto::Client, article_map: &util::ArticleMap) -> Result<(), proto::ClientError> {
-    let mut progress = ProgressBar::new(article_map.uuids.len() as u64);
+    let mut progress = ProgressBar::new(article_map.link_len());
     progress.message("indexing links: ");
 
     let mut inserter = BulkInserter::new(client);
@@ -105,7 +105,7 @@ async fn insert_links(client: proto::Client, article_map: &util::ArticleMap) -> 
                 )))
                 .await;
         }
-        progress.inc();
+        progress.add(dst_uuids.len() as u64);
     }
 
     inserter.flush().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,24 +1,26 @@
-#[macro_use] extern crate clap;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate clap;
+#[macro_use]
+extern crate lazy_static;
 
-mod util;
-mod parser;
-mod indexer;
 mod explorer;
+mod indexer;
+mod parser;
+mod util;
 
-use std::error::Error as StdError;
-use std::process::{Command, Stdio};
-use std::io::{BufRead, BufReader};
 use std::convert::TryInto;
+use std::error::Error as StdError;
+use std::io::{BufRead, BufReader};
+use std::process::{Command, Stdio};
 
-use indradb_proto as proto;
-use clap::{App, SubCommand, Arg};
-use tonic::transport::Endpoint;
+use clap::{App, Arg, SubCommand};
 use failure::Fail;
+use indradb_proto as proto;
+use tonic::transport::Endpoint;
 
 pub struct Server {
     child_id: i32,
-    address: String
+    address: String,
 }
 
 impl Server {
@@ -77,7 +79,11 @@ pub async fn main() -> Result<(), Box<dyn StdError>> {
     let matches = App::new("IndraDB wikipedia example")
         .about("demonstrates IndraDB with the wikipedia dataset")
         .subcommand(SubCommand::with_name("parse").arg(&archive_arg).arg(&archive_dump_arg))
-        .subcommand(SubCommand::with_name("index").arg(&archive_dump_arg).arg(&datastore_arg))
+        .subcommand(
+            SubCommand::with_name("index")
+                .arg(&archive_dump_arg)
+                .arg(&datastore_arg),
+        )
         .subcommand(SubCommand::with_name("explore").arg(&datastore_arg).arg(&port_arg))
         .get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,7 +11,7 @@ mod util;
 use std::convert::TryInto;
 use std::error::Error as StdError;
 use std::io::{BufRead, BufReader};
-use std::process::{Command, Stdio, Child};
+use std::process::{Child, Command, Stdio};
 
 use clap::{App, Arg, SubCommand};
 use failure::Fail;

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ pub struct Server {
 
 impl Server {
     pub fn start(database_path: &str) -> Result<Self, Box<dyn StdError>> {
-        let child = Command::new("indradb-server")
+        let child = Command::new("indradb/target/release/indradb-server")
             .args(&["--address", "127.0.0.1:0", "rocksdb", database_path])
             .env("RUST_BACKTRACE", "1")
             .stdout(Stdio::piped())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -115,8 +115,7 @@ fn read_archive(f: File) -> Result<ArticleMap, Box<dyn StdError>> {
         }
     }
 
-    println!("\rreading archive: done");
-
+    println!();
     Ok(article_map)
 }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -43,6 +43,14 @@ impl ArticleMap {
         let container = self.links.entry(src_uuid).or_insert_with(HashSet::default);
         container.insert(dst_uuid);
     }
+
+    pub fn article_len(&self) -> u64 {
+        self.uuids.len() as u64
+    }
+
+    pub fn link_len(&self) -> u64 {
+        self.links.iter().map(|(_, v)| v.len()).sum::<usize>() as u64
+    }
 }
 
 pub fn article_uuid<T: AsRef<[u8]>>(name: T) -> Uuid {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 
 use blake2b_simd::Params;
 use serde::{Deserialize, Serialize};
@@ -12,18 +12,17 @@ lazy_static! {
     };
 }
 
-// TODO: investigate memory/speed tradeoff of BTreeMap vs HashMap here
 #[derive(Serialize, Deserialize)]
 pub struct ArticleMap {
-    pub uuids: HashMap<String, Uuid>,
-    pub links: HashMap<Uuid, HashSet<Uuid>>,
+    pub uuids: BTreeMap<String, Uuid>,
+    pub links: BTreeMap<Uuid, BTreeSet<Uuid>>,
 }
 
 impl Default for ArticleMap {
     fn default() -> Self {
         Self {
-            uuids: HashMap::default(),
-            links: HashMap::default(),
+            uuids: BTreeMap::default(),
+            links: BTreeMap::default(),
         }
     }
 }
@@ -40,7 +39,7 @@ impl ArticleMap {
     }
 
     pub fn insert_link(&mut self, src_uuid: Uuid, dst_uuid: Uuid) {
-        let container = self.links.entry(src_uuid).or_insert_with(HashSet::default);
+        let container = self.links.entry(src_uuid).or_insert_with(BTreeSet::default);
         container.insert(dst_uuid);
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,8 +1,8 @@
 use std::collections::{HashMap, HashSet};
 
 use blake2b_simd::Params;
+use serde::{Deserialize, Serialize};
 use uuid::Uuid;
-use serde::{Serialize, Deserialize};
 
 lazy_static! {
     static ref HASHER_PARAMS: Params = {
@@ -16,7 +16,7 @@ lazy_static! {
 #[derive(Serialize, Deserialize)]
 pub struct ArticleMap {
     pub uuids: HashMap<String, Uuid>,
-    pub links: HashMap<Uuid, HashSet<Uuid>>
+    pub links: HashMap<Uuid, HashSet<Uuid>>,
 }
 
 impl Default for ArticleMap {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,10 +1,7 @@
-use std::convert::TryInto;
 use std::collections::{HashMap, HashSet};
 
-use indradb_proto as proto;
 use blake2b_simd::Params;
 use uuid::Uuid;
-use tonic::transport::Endpoint;
 use serde::{Serialize, Deserialize};
 
 lazy_static! {
@@ -51,9 +48,4 @@ impl ArticleMap {
 pub fn article_uuid<T: AsRef<[u8]>>(name: T) -> Uuid {
     let hash = HASHER_PARAMS.hash(name.as_ref());
     Uuid::from_slice(hash.as_bytes()).unwrap()
-}
-
-pub async fn client() -> Result<proto::Client, proto::ClientError> {
-    let endpoint: Endpoint = "http://127.0.0.1:27615".try_into().unwrap();
-    proto::Client::new(endpoint).await
 }


### PR DESCRIPTION
A bunch of cleanup from the all the changes associated with the gRPC transition:

* Dynamically bind server port so that multiple concurrent instances of indradb can run if desired
* Suppress output of indradb server
* Reuse client instance by cloning around
* Reuse tera templating engine rather than doing one-off's per request
* Apply clippy & fmt
* Use a submodule to pin to a specific version of indradb
